### PR TITLE
Chore: actuator tomcat metric 활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,8 @@ management:
       enabled: true
   server:
     port: 9292
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true


### PR DESCRIPTION
tomcat metric 중 기본으로 제공하는 session을 포함한 전부를 활성화합니다.